### PR TITLE
Fix: Better detection of custom hats to use the right indeces

### DIFF
--- a/src/MoreCustomizationsPlugin.cs
+++ b/src/MoreCustomizationsPlugin.cs
@@ -18,6 +18,8 @@ public partial class MoreCustomizationsPlugin : BaseUnityPlugin {
     internal static new ManualLogSource Logger;
     
     internal static Harmony _patcher = new(MyPluginInfo.PLUGIN_GUID);
+    // Number of base hats in the game
+    public static int BaseHatCount { get; internal set; } = 0;
     // Number of extra placeholder hats introduced by fits that override hats.
     public static int OverrideHatCount { get; internal set; } = 0;
     

--- a/src/MoreCustomizationsPlugin.cs
+++ b/src/MoreCustomizationsPlugin.cs
@@ -18,9 +18,11 @@ public partial class MoreCustomizationsPlugin : BaseUnityPlugin {
     internal static new ManualLogSource Logger;
     
     internal static Harmony _patcher = new(MyPluginInfo.PLUGIN_GUID);
-    // Number of base hats in the game
+    
+    /// <summary>Number of base hats in the game.</summary>
     public static int BaseHatCount { get; internal set; } = 0;
-    // Number of extra placeholder hats introduced by fits that override hats.
+    
+    /// <summary>Number of extra placeholder hats introduced by fits that override hats.</summary>
     public static int OverrideHatCount { get; internal set; } = 0;
     
     public static IReadOnlyDictionary<Customization.Type, IReadOnlyList<CustomizationData>> AllCustomizationsData { get; private set; }

--- a/src/Patches/PassportButtonPatch.cs
+++ b/src/Patches/PassportButtonPatch.cs
@@ -1,23 +1,21 @@
 
 using HarmonyLib;
-using System.Reflection;
-using UnityEngine;
 
 using Plugin = MoreCustomizations.MoreCustomizationsPlugin;
 
 namespace MoreCustomizations.Patches;
 
 public class PassportButtonPatch {
-        
+    
     [HarmonyPatch(typeof(PassportButton), "SetButton")]
     [HarmonyPostfix]
-    private static void SetButton(ref int ___currentIndex, CustomizationOption option, int index) {
+    private static void SetButton(ref int ___currentIndex, CustomizationOption option) {
         
         if (option == null) return;
         
-        if (option.type == Customization.Type.Hat && option.overrideHat) {
+        if (option.type == Customization.Type.Hat && ___currentIndex >= Plugin.BaseHatCount) {
             
-            ___currentIndex = option.overrideHatIndex;
+            ___currentIndex += Plugin.OverrideHatCount;
         }
     }
 }

--- a/src/Patches/PassportManagerPatch.cs
+++ b/src/Patches/PassportManagerPatch.cs
@@ -95,7 +95,7 @@ public class PassportManagerPatch {
                             
                             Plugin.Logger.LogWarning(
                                 "Could not find existing fitMaterial to copy! Using fallback material, "
-                                + "expect some visual errors"
+                                + "expect some visual errors."
                             );
                             
                             materialTemplate = FitMaterialFallback.MaterialTemplate;
@@ -142,20 +142,22 @@ public class PassportManagerPatch {
     [HarmonyTranspiler]
     public static IEnumerable<CodeInstruction> SetActiveButton(IEnumerable<CodeInstruction> instructions) {
         
-        //else if (this.activeType == Customization.Type.Hat) {
-        // num = playerData.customizationData.currentHat;
-        // 
-        //  if(num > Plugin.BaseHatCount) {
-        //      num -= Plugin.OverrideHatCount;
+        //  ...
+        //  else if (this.activeType == Customization.Type.Hat) {
+        //      
+        //      num = playerData.customizationData.currentHat;
+        //      
+        // +    if(num > Plugin.BaseHatCount) {
+        // +        num -= Plugin.OverrideHatCount;
+        // +    }
+        //      add a check if hat is custom, if so subtract the OverrideHatCount.
         //  }
-        //   ^^
-        //   add a check if hat is custom, if so subtract the OverrideHatCount
-        // }
+        //  ...
         
         var codes = instructions.ToList();
         for (int i = 0; i < codes.Count - 2; i++) {
             
-            // Look for: ldloc.0, ldfld customizationData, ldfld currentHat, stloc.0
+            //Look for: ldloc.0, ldfld customizationData, ldfld currentHat, stloc.0
             if (codes[i].opcode == OpCodes.Ldloc_0
              && codes[i + 1].opcode == OpCodes.Ldfld
              && codes[i + 1].operand.ToString().Contains("customizationData")
@@ -164,34 +166,34 @@ public class PassportManagerPatch {
              && codes[i + 3].opcode == OpCodes.Stloc_1
             ) {
                 
-                // Output the sequence up to Ldfld
+                //Output the sequence up to Ldfld
                 yield return codes[i];
                 yield return codes[i + 1];
                 yield return codes[i + 2];
                 
-                // Inject: if (num > Plugin.BaseHatCount) num -= Plugin.OverrideHatCount;
-                // Stack: <currentHat>
+                //Inject: if (num > Plugin.BaseHatCount) num -= Plugin.OverrideHatCount;
+                //Stack: <currentHat>
                 
-                // Duplicate the value so we can compare and still have original for subtraction if needed
+                //Duplicate the value so we can compare and still have original for subtraction if needed.
                 yield return new CodeInstruction(OpCodes.Dup);
                 
                 yield return new CodeInstruction(OpCodes.Call, AccessTools.Property(typeof(Plugin), nameof(Plugin.BaseHatCount)).GetGetMethod(true));
                 
-                // if (dup > BaseHatCount) -> leave original on stack and continue
-                // We'll branch if less than or equal to BaseHatCount to skip subtraction
+                //if (dup > BaseHatCount) -> leave original on stack and continue
+                //We'll branch if less than or equal to BaseHatCount to skip subtraction.
                 var skipLabel = new Label();
                 yield return new CodeInstruction(OpCodes.Ble_S) { operand = skipLabel };
                 
-                // call get_OverrideHatCount and subtract
+                //call get_OverrideHatCount and subtract.
                 yield return new CodeInstruction(OpCodes.Call, AccessTools.Property(typeof(Plugin), nameof(Plugin.OverrideHatCount)).GetGetMethod(true));
                 yield return new CodeInstruction(OpCodes.Sub);
                 
-                // Mark skip label position
+                //Mark skip label position.
                 var nop = new CodeInstruction(OpCodes.Nop);
                 nop.labels.Add(skipLabel);
                 yield return nop;
                 
-                // Output stloc.0
+                //Output stloc.0
                 yield return codes[i + 3];
                 
                 i += 3;
@@ -200,10 +202,11 @@ public class PassportManagerPatch {
             yield return codes[i];
         }
         
-        // Yield remaining codes
+        //Yield remaining codes.
         for (int k = codes.Count - 2; k < codes.Count; k++) {
             
-            if (k >= 0) yield return codes[k];
+            if (k >= 0)
+                yield return codes[k];
         }
     }
     

--- a/src/Patches/PassportManagerPatch.cs
+++ b/src/Patches/PassportManagerPatch.cs
@@ -41,6 +41,7 @@ public class PassportManagerPatch {
         var fits        = new List<CustomizationOption>(customization.fits);
         var hats        = new List<CustomizationOption>(customization.hats);
         
+        Plugin.BaseHatCount = hats.Count;
         Plugin.OverrideHatCount = 0;
         
         foreach (var fit in fits) {
@@ -123,10 +124,6 @@ public class PassportManagerPatch {
                         option.fitMaterialOverridePants = Object.Instantiate(materialTemplate);
                         option.fitMaterialOverridePants.SetTexture("_MainTex", fitData.FitOverridePantsTexture);
                     }
-                } else if (type == Customization.Type.Hat) {
-                    
-                    option.overrideHat = true;
-                    option.overrideHatIndex = hats.Count + Plugin.OverrideHatCount;
                 }
                 
                 customizationOptions.Add(option);
@@ -139,6 +136,75 @@ public class PassportManagerPatch {
         customization.mouths      = mouths.ToArray();
         customization.fits        = fits.ToArray();
         customization.hats        = hats.ToArray();
+    }
+    
+    [HarmonyPatch(typeof(PassportManager), "SetActiveButton")]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> SetActiveButton(IEnumerable<CodeInstruction> instructions) {
+        
+        //else if (this.activeType == Customization.Type.Hat) {
+        // num = playerData.customizationData.currentHat;
+        // 
+        //  if(num > Plugin.BaseHatCount) {
+        //      num -= Plugin.OverrideHatCount;
+        //  }
+        //   ^^
+        //   add a check if hat is custom, if so subtract the OverrideHatCount
+        // }
+        
+        var codes = instructions.ToList();
+        for (int i = 0; i < codes.Count - 2; i++) {
+            
+            // Look for: ldloc.0, ldfld customizationData, ldfld currentHat, stloc.0
+            if (codes[i].opcode == OpCodes.Ldloc_0
+             && codes[i + 1].opcode == OpCodes.Ldfld
+             && codes[i + 1].operand.ToString().Contains("customizationData")
+             && codes[i + 2].opcode == OpCodes.Ldfld
+             && codes[i + 2].operand.ToString().Contains("currentHat")
+             && codes[i + 3].opcode == OpCodes.Stloc_1
+            ) {
+                
+                // Output the sequence up to Ldfld
+                yield return codes[i];
+                yield return codes[i + 1];
+                yield return codes[i + 2];
+                
+                // Inject: if (num > Plugin.BaseHatCount) num -= Plugin.OverrideHatCount;
+                // Stack: <currentHat>
+                
+                // Duplicate the value so we can compare and still have original for subtraction if needed
+                yield return new CodeInstruction(OpCodes.Dup);
+                
+                yield return new CodeInstruction(OpCodes.Call, AccessTools.Property(typeof(Plugin), nameof(Plugin.BaseHatCount)).GetGetMethod(true));
+                
+                // if (dup > BaseHatCount) -> leave original on stack and continue
+                // We'll branch if less than or equal to BaseHatCount to skip subtraction
+                var skipLabel = new Label();
+                yield return new CodeInstruction(OpCodes.Ble_S) { operand = skipLabel };
+                
+                // call get_OverrideHatCount and subtract
+                yield return new CodeInstruction(OpCodes.Call, AccessTools.Property(typeof(Plugin), nameof(Plugin.OverrideHatCount)).GetGetMethod(true));
+                yield return new CodeInstruction(OpCodes.Sub);
+                
+                // Mark skip label position
+                var nop = new CodeInstruction(OpCodes.Nop);
+                nop.labels.Add(skipLabel);
+                yield return nop;
+                
+                // Output stloc.0
+                yield return codes[i + 3];
+                
+                i += 3;
+                continue;
+            }
+            yield return codes[i];
+        }
+        
+        // Yield remaining codes
+        for (int k = codes.Count - 2; k < codes.Count; k++) {
+            
+            if (k >= 0) yield return codes[k];
+        }
     }
     
     [HarmonyPatch(typeof(PassportManager), "CameraIn")]


### PR DESCRIPTION
This should fix the wrong highlighting and also make the index shifting (if needed) better from #18.

It tracks the default hats count. So anything with a higher index than the base count is a custom hat and can be taken into account later. This makes the workarround with overideHat and overrideHatIndex unnecessary and simplyfies it.

For the highlighting I needed to add a new transpiler for the passportManager to correct the index if its a custom hat.

Fixes #21.